### PR TITLE
fixed typo with delete func in map

### DIFF
--- a/README.md
+++ b/README.md
@@ -3099,7 +3099,7 @@ Here's how the syntax looks:
 
 ```go
 ...
-delete(m,
+delete(m, "a")
 ```
 
 The first argument is the map, and the second is the key we want to delete.


### PR DESCRIPTION
## What
There was a typo in maps delete function, the second arg was missing so fixed it.