### PR TITLE
fix: correct variable name from `c` to `ch` in fmt.Println

### DIFF
--- a/README.md
+++ b/README.md
@@ -4661,13 +4661,13 @@ var ch chan T
 
 Here, we prefix our type `T` which is the data type of the value we want to send and receive with the keyword `chan` which stands for a channel.
 
-Let's try printing the value of our channel `c` of type `string`.
+Let's try printing the value of our channel `ch` of type `string`.
 
 ```go
 func main() {
 	var ch chan string
 
-	fmt.Println(c)
+	fmt.Println(ch)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -4684,7 +4684,7 @@ So, similar to slices we can initialize our channel using the built-in `make` fu
 func main() {
 	ch := make(chan string)
 
-	fmt.Println(c)
+	fmt.Println(ch)
 }
 ```
 


### PR DESCRIPTION
# Changelog

<!-- Please include a summary of the change and which issue is fixed. -->
